### PR TITLE
Remove find_start_codes from hello_video

### DIFF
--- a/opt/vc/src/hello_pi/hello_video/video.c
+++ b/opt/vc/src/hello_pi/hello_video/video.c
@@ -46,7 +46,6 @@ static int video_decode_test(char *filename)
    int status = 0;
    unsigned char *data = NULL;
    unsigned int data_len = 0;
-   int find_start_codes = 0;
    int packet_size = 16<<10;   
 
    memset(list, 0, sizeof(list));
@@ -68,15 +67,6 @@ static int video_decode_test(char *filename)
       return -4;
    }
 
-   if(find_start_codes && (data = malloc(packet_size+4)) == NULL)
-   {
-      status = -16;
-      if(OMX_Deinit() != OMX_ErrorNone)
-         status = -17;
-      ilclient_destroy(client);
-      fclose(in);
-      return status;
-   }
    // create video_decode
    if(ilclient_create_component(client, &video_decode, "video_decode", ILCLIENT_DISABLE_ALL_PORTS | ILCLIENT_ENABLE_INPUT_BUFFERS) != 0)
       status = -14;
@@ -137,9 +127,9 @@ static int video_decode_test(char *filename)
       while((buf = ilclient_get_input_buffer(video_decode, 130, 1)) != NULL)
       {
          // feed data and wait until we get port settings changed
-         unsigned char *dest = find_start_codes ? data + data_len : buf->pBuffer;
+         unsigned char *dest = buf->pBuffer;
 
-         data_len += fread(dest, 1, packet_size+(find_start_codes*4)-data_len, in);
+         data_len += fread(dest, 1, packet_size-data_len, in);
 
          if(port_settings_changed == 0 &&
             ((data_len > 0 && ilclient_remove_event(video_decode, OMX_EventPortSettingsChanged, 131, 0, 0, 1) == 0) ||
@@ -168,53 +158,8 @@ static int video_decode_test(char *filename)
          if(!data_len)
             break;
 
-         if(find_start_codes)
-         {
-            int i, start = -1, len = 0;
-            int max_len = data_len > packet_size ? packet_size : data_len;
-            for(i=2; i<max_len; i++)
-            {
-               if(data[i-2] == 0 && data[i-1] == 0 && data[i] == 1)
-               {
-                  len = 3;
-                  start = i-2;
-
-                  // check for 4 byte start code
-                  if(i > 2 && data[i-3] == 0)
-                  {
-                     len++;
-                     start--;
-                  }
-
-                  break;
-               }
-            }
-
-            if(start == 0)
-            {
-               // start code is next, so just send that
-               buf->nFilledLen = len;
-            }
-            else if(start == -1)
-            {
-               // no start codes seen, send the first block
-               buf->nFilledLen = max_len;
-            }
-            else
-            {
-               // start code in the middle of the buffer, send up to the code
-               buf->nFilledLen = start;
-            }
-
-            memcpy(buf->pBuffer, data, buf->nFilledLen);
-            memmove(data, data + buf->nFilledLen, data_len - buf->nFilledLen);
-            data_len -= buf->nFilledLen;
-         }
-         else
-         {
-            buf->nFilledLen = data_len;
-            data_len = 0;
-         }
+         buf->nFilledLen = data_len;
+         data_len = 0;
 
          buf->nOffset = 0;
          if(first_packet)


### PR DESCRIPTION
The hello_video sample (and the hello_videocube sample which is derived from it) contain a bunch of code which is never executed because a variable named find_start_codes is always set to 0. It looks like this code is defunct.

This patch removes the vestigial(?) find_start_codes
