### PR TITLE
Fix hello_pi compilation error

### DIFF
--- a/hardfp/opt/vc/src/hello_pi/Makefile.include
+++ b/hardfp/opt/vc/src/hello_pi/Makefile.include
@@ -1,7 +1,7 @@
 
 CFLAGS+=-DSTANDALONE -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -U_FORTIFY_SOURCE -Wall -g -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT -ftree-vectorize -pipe -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM -Wno-psabi
 
-LDFLAGS+=-L$(SDKSTAGE)/opt/vc/lib/ -lGLESv2 -lEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -L../libs/ilclient -L../libs/vgfont
+LDFLAGS+=-L$(SDKSTAGE)/opt/vc/lib/ -lGLESv2 -lEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -lm -L../libs/ilclient -L../libs/vgfont
 
 INCLUDES+=-I$(SDKSTAGE)/opt/vc/include/ -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads -I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux -I./ -I../libs/ilclient -I../libs/vgfont
 


### PR DESCRIPTION
When running rebuild.sh on Raspbian with latest updates, the following error occurs:

```
cc -o hello_teapot.bin -Wl,--whole-archive triangle.o video.o models.o -lilclient -L/opt/vc/lib/ -lGLESv2 -lEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -L../libs/ilclient -L../libs/vgfont -Wl,--no-whole-archive -rdynamic
/usr/bin/ld: models.o: undefined reference to symbol 'sqrtf@@GLIBC_2.4'
//lib/arm-linux-gnueabihf/libm.so.6: error adding symbols: DSO missing from command line
collect2: ld returned 1 exit status
../Makefile.include:19: recipe for target 'hello_teapot.bin' failed
make: *** [hello_teapot.bin] Error 1
```

Adding libm to linked libraries fixes this.
