### PR TITLE
Add a script to generate the file to submit to the LVFS

### DIFF
--- a/boot/firmware.inf
+++ b/boot/firmware.inf
@@ -1,0 +1,19 @@
+; Copyright (C) 2015 Richard Hughes
+
+[Version]
+Class=Firmware
+ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+
+[Firmware_CopyFiles]
+firmware.bin
+
+[Firmware_AddReg]
+HKR,,FirmwareId,,{c77029fe-ffb2-3706-dc67-67af4a132afd}
+HKR,,FirmwareVersion,%REG_DWORD%,0x0000000
+HKR,,FirmwareFilename,,firmware.bin
+
+[Strings]
+Provider     = "Raspberry Pi Foundation"
+MfgName      = "Raspberry Pi"
+FirmwareDesc = "Raspberry Pi Firmware"
+DiskName     = "Firmware for the Raspberry Pi"

--- a/boot/firmware.metainfo.xml
+++ b/boot/firmware.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2015 Richard Hughes  -->
+<component type="firmware">
+  <id>c77029fe-ffb2-3706-dc67-67af4a132afd</id>
+  <name>Raspberry Pi Device Update</name>
+  <summary>Firmware for the Raspberry Pi</summary>
+  <description>
+    <p>
+      Updating the firmware on your Raspberry Pi device improves
+      performance and fixes reported bugs.
+    </p>
+  </description>
+  <url type="homepage">https://www.raspberrypi.org/</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>proprietary</project_license>
+  <developer_name>Raspberry Pi Foundation</developer_name>
+  <releases>
+    <release version="20150803">
+      <description>
+        <p>Fix unwanted lock release with turbo mode.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/boot/generate-cab.sh
+++ b/boot/generate-cab.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/sh
+tar -cf firmware.bin			\
+	*.elf				\
+	*.dat				\
+	*.dtb				\
+	*.img				\
+	COPYING.*			\
+	LICENCE.*			\
+	overlays/*.dtb			\
+	overlays/README
+gcab --create rpi-firmware-`date +"%Y%m%d"`.cab	\
+	firmware.bin			\
+	LICENCE.*			\
+	firmware.inf			\
+	firmware.metainfo.xml


### PR DESCRIPTION
The LVFS site https://beta-lvfs.rhcloud.com/ accepts and mirrors .cab files and
new versions of fwupd can update the firmware on the Raspberry Pi automatically.
