### PR TITLE
Update video.c

### DIFF
--- a/opt/vc/src/hello_pi/hello_video/video.c
+++ b/opt/vc/src/hello_pi/hello_video/video.c
@@ -183,7 +183,7 @@ static int video_decode_test(char *filename)
 
       // wait for EOS from render
       ilclient_wait_for_event(video_render, OMX_EventBufferFlag, 90, 0, OMX_BUFFERFLAG_EOS, 0,
-                              ILCLIENT_BUFFER_FLAG_EOS, 10000);
+                              ILCLIENT_BUFFER_FLAG_EOS, -1);
 
       // need to flush the renderer to allow video_decode to disable its input port
       ilclient_flush_tunnels(tunnel, 0);


### PR DESCRIPTION
Remove the timout, to avoid the application quits before the ending of some videos.
(Application used to hang before last commit, now it quits, either, the only way to watch some video files till the end is to remove timeout completely like I am suggesting now, or to incrase it, but I dont now what should be better pratice.