### PR TITLE
Typo fix for README

### DIFF
--- a/README
+++ b/README
@@ -4,7 +4,7 @@ kernel and modules, userspace libraries, and bootloader/GPU firmware.
 A rough guide to this repository and the licences covering its contents is 
 below (check the appropriate directories for full licence details):
 
-* ./boot: *start.elf, bootcode.bin are the GPU firmware and bootloaders. 
+* ./boot: start*.elf, bootcode.bin are the GPU firmware and bootloaders.
   Their licence is described in 'LICENCE.broadcom'. The kernel.img files
   are builds of the Linux kernel, released under the GPL (see COPYING.linux)
 * ./debug: pre-build modules for the kernel_debug.img


### PR DESCRIPTION
Fix an apparent typo in the README file, clarifying licensing terms of binary ./boot/start_*.elf files.