### PR TITLE
Fix typos (mostly in comments and documentation)

### DIFF
--- a/documentation/ilcomponents/camera.html
+++ b/documentation/ilcomponents/camera.html
@@ -414,7 +414,7 @@ unloaded, extending the startup latency.
   power down the sensor, but keeping all memory allocated as required by
   the component state.
  <tr valign="top"><td><tt><a href="prop.html#OMX_IndexParamBrcmCameraInputAspectRatio">OMX_IndexParamBrcmCameraInputAspectRatio</a></tt>
-<td> Sensor aspect ratio selection. Query / set the prefered aspect ratio
+<td> Sensor aspect ratio selection. Query / set the preferred aspect ratio
   of the sensor CDI mode. The CDI will use the nearest value to this.
   If both are left as 0, then the aspect ratio of the requested output
   mode is used to bias the sensor mode selection.

--- a/documentation/ilcomponents/image_decode.html
+++ b/documentation/ilcomponents/image_decode.html
@@ -73,7 +73,7 @@ into raw pixels which are emitted on the output port.
   has been received the stream is opened, and the port format will
   reflect the parameters of the selected port stream, if these are
   different from the values at the time a port settings changed event
-  will be emitted.  To ensure that this event is emmitted, this port
+  will be emitted.  To ensure that this event is emitted, this port
   supports setting the compression format to OMX_IMAGE_CodingAutoDetect,
   which will always be different from the discovered format of
   OMX_IMAGE_CodingUnused.

--- a/documentation/ilcomponents/prop.html
+++ b/documentation/ilcomponents/prop.html
@@ -268,7 +268,7 @@ This index uses the standard IL structure <tt>OMX_PARAM_U32TYPE</tt><p>
 For each port on the clock component, requests for media times may be
  made.  These are typically done one per video frame to allow for
  scheduling the display of that frame at the correct time.  If a
- request is made after the time has occured, then that frame will be
+ request is made after the time has occurred, then that frame will be
  displayed late, and the clock component keeps a per-port record of the
  number of times this occurs.  This record can be read using this
  index.<p>
@@ -1985,7 +1985,7 @@ typedef struct OMX_PARAM_BRCMASPECTRATIOTYPE {
     OMX_U32 nHeight;
 } OMX_PARAM_BRCMASPECTRATIOTYPE;
 </pre><p>
-Query / set the prefered aspect ratio of the sensor CDI mode. The CDI will use the nearest value to this.
+Query / set the preferred aspect ratio of the sensor CDI mode. The CDI will use the nearest value to this.
   If both are left as 0, then the aspect ratio of the requested output
   mode is used to bias the sensor mode selection.
   

--- a/documentation/ilcomponents/read_media.html
+++ b/documentation/ilcomponents/read_media.html
@@ -104,7 +104,7 @@ input port.
 <td> This config parameter serves as a notification for DivX DRM protected
   rental files.  Clients should detect any changes in this parameter
   using <tt>OMX_IndexConfigRequestCallback</tt>.  It will be populated with the
-  current view count and the maximum permissable view count if a DivX
+  current view count and the maximum permissible view count if a DivX
   DRM rental file is opened.  Clients should respond by setting
   <tt>OMX_IndexConfigConfirmView</tt> config parameter.
  <tr valign="top"><td><tt><a href="prop.html#OMX_IndexConfigRequestCallback">OMX_IndexConfigRequestCallback</a></tt>
@@ -120,7 +120,7 @@ input port.
 <td> This config parameter serves as a notification for DivX DRM protected rental files.
   Host applications should detect any changes in this parameter.
   It has two members, nCurrentView and nMaxView, which will be populated with
-  the current view count and the maximum permissable view count if a DivX DRM rental
+  the current view count and the maximum permissible view count if a DivX DRM rental
   file is opened. Host applications should respond by setting <tt>OMX_IndexConfigConfirmView</tt>
   config parameter.
  <tr valign="top"><td><tt><a href="prop.html#OMX_IndexParamComponentName">OMX_IndexParamComponentName</a></tt>

--- a/hardfp/opt/vc/include/IL/OMX_Audio.h
+++ b/hardfp/opt/vc/include/IL/OMX_Audio.h
@@ -1340,7 +1340,7 @@ typedef struct OMX_AUDIO_CONFIG_REVERBERATIONTYPE {
 } OMX_AUDIO_CONFIG_REVERBERATIONTYPE;
 
 
-/** Possible settings for the Echo Cancelation structure to use 
+/** Possible settings for the Echo Cancellation structure to use
  * @ingroup effects
  */
 typedef enum OMX_AUDIO_ECHOCANTYPE {
@@ -1357,16 +1357,16 @@ typedef enum OMX_AUDIO_ECHOCANTYPE {
 } OMX_AUDIO_ECHOCANTYPE;
 
 
-/** Enable / Disable for echo cancelation, which removes undesired echo's
+/** Enable / Disable for echo cancellation, which removes undesired echo's
  *  from the audio
  * @ingroup effects
  */ 
-typedef struct OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE {
+typedef struct OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE {
     OMX_U32 nSize;             /**< size of the structure in bytes */
     OMX_VERSIONTYPE nVersion;  /**< OMX specification version information */
     OMX_U32 nPortIndex;        /**< port that this structure applies to */
-    OMX_AUDIO_ECHOCANTYPE eEchoCancelation; /**< Echo cancelation settings */
-} OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE;
+    OMX_AUDIO_ECHOCANTYPE eEchoCancellation; /**< Echo cancellation settings */
+} OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE;
 
 
 /** Enable / Disable for noise reduction, which undesired noise from

--- a/hardfp/opt/vc/include/IL/OMX_Core.h
+++ b/hardfp/opt/vc/include/IL/OMX_Core.h
@@ -182,7 +182,7 @@ typedef enum OMX_ERRORTYPE
       lost resulting in the component returning to the loaded state */
   OMX_ErrorResourcesLost = (OMX_S32) 0x8000100D,
 
-  /** No more indicies can be enumerated */
+  /** No more indices can be enumerated */
   OMX_ErrorNoMore = (OMX_S32) 0x8000100E,
 
   /** The component detected a version mismatch */
@@ -219,7 +219,7 @@ typedef enum OMX_ERRORTYPE
       the non-supplier to return a buffer via an EmptyThisBuffer or FillThisBuffer call. */
   OMX_ErrorPortUnresponsiveDuringStop = (OMX_S32) 0x80001016,
 
-  /** Attempting a state transtion that is not allowed */
+  /** Attempting a state transition that is not allowed */
   OMX_ErrorIncorrectStateTransition = (OMX_S32) 0x80001017,
 
   /* Attempting a command that is not allowed during the present state. */
@@ -513,7 +513,7 @@ typedef struct OMX_PORT_PARAM_TYPE {
 /** @ingroup comp */
 typedef enum OMX_EVENTTYPE
 {
-    OMX_EventCmdComplete,         /**< component has sucessfully completed a command */
+    OMX_EventCmdComplete,         /**< component has successfully completed a command */
     OMX_EventError,               /**< component has detected an error condition */
     OMX_EventMark,                /**< component has detected a buffer mark */
     OMX_EventPortSettingsChanged, /**< component is reported a port settings change */
@@ -1261,7 +1261,7 @@ OMX_API OMX_ERRORTYPE OMX_APIENTRY OMX_Deinit(void);
     @param [in] nNameLength
         number of characters in the cComponentName string.  With all 
         component name strings restricted to less than 128 characters 
-        (including the trailing null) it is recomended that the caller
+        (including the trailing null) it is recommended that the caller
         provide a input string for the cComponentName of 128 characters.
     @param [in] nIndex
         number containing the enumeration index for the component. 

--- a/hardfp/opt/vc/include/IL/OMX_Index.h
+++ b/hardfp/opt/vc/include/IL/OMX_Index.h
@@ -130,7 +130,7 @@ typedef enum OMX_INDEXTYPE {
     OMX_IndexConfigAudioChannelMute,        /**< reference: OMX_AUDIO_CONFIG_CHANNELMUTETYPE */
     OMX_IndexConfigAudioMute,               /**< reference: OMX_AUDIO_CONFIG_MUTETYPE */
     OMX_IndexConfigAudioLoudness,           /**< reference: OMX_AUDIO_CONFIG_LOUDNESSTYPE */
-    OMX_IndexConfigAudioEchoCancelation,    /**< reference: OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE */
+    OMX_IndexConfigAudioEchoCancellation,   /**< reference: OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE */
     OMX_IndexConfigAudioNoiseReduction,     /**< reference: OMX_AUDIO_CONFIG_NOISEREDUCTIONTYPE */
     OMX_IndexConfigAudioBass,               /**< reference: OMX_AUDIO_CONFIG_BASSTYPE */
     OMX_IndexConfigAudioTreble,             /**< reference: OMX_AUDIO_CONFIG_TREBLETYPE */

--- a/hardfp/opt/vc/include/IL/OMX_Other.h
+++ b/hardfp/opt/vc/include/IL/OMX_Other.h
@@ -208,7 +208,7 @@ typedef struct OMX_TIME_CONFIG_MEDIATIMEREQUESTTYPE {
  *   Upon scale changes the clock component clears the nClientPrivate data, sends the current
  *   media time and sets the nScale to the new scale via the client port. It emits a 
  *   OMX_TIME_MEDIATIMETYPE to all clients independent of any requests. This allows clients to 
- *   alter processing to accomodate scaling. For instance a video component might skip inter-frames 
+ *   alter processing to accommodate scaling. For instance a video component might skip inter-frames
  *   in the case of extreme fastforward. Likewise an audio component might add or remove samples 
  *   from an audio frame to scale audio data. 
  *
@@ -247,7 +247,7 @@ typedef struct OMX_TIME_MEDIATIMETYPE {
 
 /** Structure representing the current media time scale factor. Applicable only to clock 
  *  component, other components see scale changes via OMX_TIME_MEDIATIMETYPE buffers sent via
- *  the clock component client ports. Upon recieving this config the clock component changes 
+ *  the clock component client ports. Upon receiving this config the clock component changes
  *  the rate by which the media time increases or decreases effectively implementing trick modes. 
  */ 
 typedef struct OMX_TIME_CONFIG_SCALETYPE {

--- a/hardfp/opt/vc/include/IL/OMX_Types.h
+++ b/hardfp/opt/vc/include/IL/OMX_Types.h
@@ -282,7 +282,7 @@ typedef struct OMX_BS32 {
 /** Structure representing some time or duration in microseconds. This structure
   *  must be interpreted as a signed 64 bit value. The quantity is signed to accommodate 
   *  negative deltas and preroll scenarios. The quantity is represented in microseconds 
-  *  to accomodate high resolution timestamps (e.g. DVD presentation timestamps based
+  *  to accommodate high resolution timestamps (e.g. DVD presentation timestamps based
   *  on a 90kHz clock) and to allow more accurate and synchronized delivery (e.g. 
   *  individual audio samples delivered at 192 kHz). The quantity is 64 bit to 
   *  accommodate a large dynamic range (signed 32 bit values would allow only for plus

--- a/hardfp/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Audio.h
+++ b/hardfp/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Audio.h
@@ -1340,7 +1340,7 @@ typedef struct OMX_AUDIO_CONFIG_REVERBERATIONTYPE {
 } OMX_AUDIO_CONFIG_REVERBERATIONTYPE;
 
 
-/** Possible settings for the Echo Cancelation structure to use 
+/** Possible settings for the Echo Cancellation structure to use
  * @ingroup effects
  */
 typedef enum OMX_AUDIO_ECHOCANTYPE {
@@ -1357,16 +1357,16 @@ typedef enum OMX_AUDIO_ECHOCANTYPE {
 } OMX_AUDIO_ECHOCANTYPE;
 
 
-/** Enable / Disable for echo cancelation, which removes undesired echo's
+/** Enable / Disable for echo cancellation, which removes undesired echo's
  *  from the audio
  * @ingroup effects
  */ 
-typedef struct OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE {
+typedef struct OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE {
     OMX_U32 nSize;             /**< size of the structure in bytes */
     OMX_VERSIONTYPE nVersion;  /**< OMX specification version information */
     OMX_U32 nPortIndex;        /**< port that this structure applies to */
-    OMX_AUDIO_ECHOCANTYPE eEchoCancelation; /**< Echo cancelation settings */
-} OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE;
+    OMX_AUDIO_ECHOCANTYPE eEchoCancellation; /**< Echo cancellation settings */
+} OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE;
 
 
 /** Enable / Disable for noise reduction, which undesired noise from

--- a/hardfp/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Core.h
+++ b/hardfp/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Core.h
@@ -182,7 +182,7 @@ typedef enum OMX_ERRORTYPE
       lost resulting in the component returning to the loaded state */
   OMX_ErrorResourcesLost = (OMX_S32) 0x8000100D,
 
-  /** No more indicies can be enumerated */
+  /** No more indices can be enumerated */
   OMX_ErrorNoMore = (OMX_S32) 0x8000100E,
 
   /** The component detected a version mismatch */
@@ -219,7 +219,7 @@ typedef enum OMX_ERRORTYPE
       the non-supplier to return a buffer via an EmptyThisBuffer or FillThisBuffer call. */
   OMX_ErrorPortUnresponsiveDuringStop = (OMX_S32) 0x80001016,
 
-  /** Attempting a state transtion that is not allowed */
+  /** Attempting a state transition that is not allowed */
   OMX_ErrorIncorrectStateTransition = (OMX_S32) 0x80001017,
 
   /* Attempting a command that is not allowed during the present state. */
@@ -513,7 +513,7 @@ typedef struct OMX_PORT_PARAM_TYPE {
 /** @ingroup comp */
 typedef enum OMX_EVENTTYPE
 {
-    OMX_EventCmdComplete,         /**< component has sucessfully completed a command */
+    OMX_EventCmdComplete,         /**< component has successfully completed a command */
     OMX_EventError,               /**< component has detected an error condition */
     OMX_EventMark,                /**< component has detected a buffer mark */
     OMX_EventPortSettingsChanged, /**< component is reported a port settings change */
@@ -1261,7 +1261,7 @@ OMX_API OMX_ERRORTYPE OMX_APIENTRY OMX_Deinit(void);
     @param [in] nNameLength
         number of characters in the cComponentName string.  With all 
         component name strings restricted to less than 128 characters 
-        (including the trailing null) it is recomended that the caller
+        (including the trailing null) it is recommended that the caller
         provide a input string for the cComponentName of 128 characters.
     @param [in] nIndex
         number containing the enumeration index for the component. 

--- a/hardfp/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Index.h
+++ b/hardfp/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Index.h
@@ -130,7 +130,7 @@ typedef enum OMX_INDEXTYPE {
     OMX_IndexConfigAudioChannelMute,        /**< reference: OMX_AUDIO_CONFIG_CHANNELMUTETYPE */
     OMX_IndexConfigAudioMute,               /**< reference: OMX_AUDIO_CONFIG_MUTETYPE */
     OMX_IndexConfigAudioLoudness,           /**< reference: OMX_AUDIO_CONFIG_LOUDNESSTYPE */
-    OMX_IndexConfigAudioEchoCancelation,    /**< reference: OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE */
+    OMX_IndexConfigAudioEchoCancellation,   /**< reference: OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE */
     OMX_IndexConfigAudioNoiseReduction,     /**< reference: OMX_AUDIO_CONFIG_NOISEREDUCTIONTYPE */
     OMX_IndexConfigAudioBass,               /**< reference: OMX_AUDIO_CONFIG_BASSTYPE */
     OMX_IndexConfigAudioTreble,             /**< reference: OMX_AUDIO_CONFIG_TREBLETYPE */

--- a/hardfp/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Other.h
+++ b/hardfp/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Other.h
@@ -208,7 +208,7 @@ typedef struct OMX_TIME_CONFIG_MEDIATIMEREQUESTTYPE {
  *   Upon scale changes the clock component clears the nClientPrivate data, sends the current
  *   media time and sets the nScale to the new scale via the client port. It emits a 
  *   OMX_TIME_MEDIATIMETYPE to all clients independent of any requests. This allows clients to 
- *   alter processing to accomodate scaling. For instance a video component might skip inter-frames 
+ *   alter processing to accommodate scaling. For instance a video component might skip inter-frames
  *   in the case of extreme fastforward. Likewise an audio component might add or remove samples 
  *   from an audio frame to scale audio data. 
  *
@@ -247,7 +247,7 @@ typedef struct OMX_TIME_MEDIATIMETYPE {
 
 /** Structure representing the current media time scale factor. Applicable only to clock 
  *  component, other components see scale changes via OMX_TIME_MEDIATIMETYPE buffers sent via
- *  the clock component client ports. Upon recieving this config the clock component changes 
+ *  the clock component client ports. Upon receiving this config the clock component changes
  *  the rate by which the media time increases or decreases effectively implementing trick modes. 
  */ 
 typedef struct OMX_TIME_CONFIG_SCALETYPE {

--- a/hardfp/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Types.h
+++ b/hardfp/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Types.h
@@ -282,7 +282,7 @@ typedef struct OMX_BS32 {
 /** Structure representing some time or duration in microseconds. This structure
   *  must be interpreted as a signed 64 bit value. The quantity is signed to accommodate 
   *  negative deltas and preroll scenarios. The quantity is represented in microseconds 
-  *  to accomodate high resolution timestamps (e.g. DVD presentation timestamps based
+  *  to accommodate high resolution timestamps (e.g. DVD presentation timestamps based
   *  on a 90kHz clock) and to allow more accurate and synchronized delivery (e.g. 
   *  individual audio samples delivered at 192 kHz). The quantity is 64 bit to 
   *  accommodate a large dynamic range (signed 32 bit values would allow only for plus

--- a/hardfp/opt/vc/src/hello_pi/libs/ilclient/ilclient.h
+++ b/hardfp/opt/vc/src/hello_pi/libs/ilclient/ilclient.h
@@ -508,7 +508,7 @@ VCHPRE_ void VCHPOST_  ilclient_state_transition(COMPONENT_T *list[],
  * given component.  This function sends the disable port message to
  * the component and waits for the component to signal that this has
  * taken place.  If the port is already disabled, this is treated as a
- * sucess.
+ * success.
  *
  * @param comp The component containing the port to disable.
  *
@@ -526,7 +526,7 @@ VCHPRE_ void VCHPOST_ ilclient_disable_port(COMPONENT_T *comp,
  * given component.  This function sends the enable port message to
  * the component and waits for the component to signal that this has
  * taken place.  If the port is already disabled, this is treated as a
- * sucess.
+ * success.
  *
  * @param comp The component containing the port to enable.
  *

--- a/opt/vc/include/IL/OMX_Audio.h
+++ b/opt/vc/include/IL/OMX_Audio.h
@@ -1340,7 +1340,7 @@ typedef struct OMX_AUDIO_CONFIG_REVERBERATIONTYPE {
 } OMX_AUDIO_CONFIG_REVERBERATIONTYPE;
 
 
-/** Possible settings for the Echo Cancelation structure to use 
+/** Possible settings for the Echo Cancellation structure to use
  * @ingroup effects
  */
 typedef enum OMX_AUDIO_ECHOCANTYPE {
@@ -1357,16 +1357,16 @@ typedef enum OMX_AUDIO_ECHOCANTYPE {
 } OMX_AUDIO_ECHOCANTYPE;
 
 
-/** Enable / Disable for echo cancelation, which removes undesired echo's
+/** Enable / Disable for echo cancellation, which removes undesired echo's
  *  from the audio
  * @ingroup effects
  */ 
-typedef struct OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE {
+typedef struct OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE {
     OMX_U32 nSize;             /**< size of the structure in bytes */
     OMX_VERSIONTYPE nVersion;  /**< OMX specification version information */
     OMX_U32 nPortIndex;        /**< port that this structure applies to */
-    OMX_AUDIO_ECHOCANTYPE eEchoCancelation; /**< Echo cancelation settings */
-} OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE;
+    OMX_AUDIO_ECHOCANTYPE eEchoCancellation; /**< Echo cancellation settings */
+} OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE;
 
 
 /** Enable / Disable for noise reduction, which undesired noise from

--- a/opt/vc/include/IL/OMX_Core.h
+++ b/opt/vc/include/IL/OMX_Core.h
@@ -182,7 +182,7 @@ typedef enum OMX_ERRORTYPE
       lost resulting in the component returning to the loaded state */
   OMX_ErrorResourcesLost = (OMX_S32) 0x8000100D,
 
-  /** No more indicies can be enumerated */
+  /** No more indices can be enumerated */
   OMX_ErrorNoMore = (OMX_S32) 0x8000100E,
 
   /** The component detected a version mismatch */
@@ -219,7 +219,7 @@ typedef enum OMX_ERRORTYPE
       the non-supplier to return a buffer via an EmptyThisBuffer or FillThisBuffer call. */
   OMX_ErrorPortUnresponsiveDuringStop = (OMX_S32) 0x80001016,
 
-  /** Attempting a state transtion that is not allowed */
+  /** Attempting a state transition that is not allowed */
   OMX_ErrorIncorrectStateTransition = (OMX_S32) 0x80001017,
 
   /* Attempting a command that is not allowed during the present state. */
@@ -513,7 +513,7 @@ typedef struct OMX_PORT_PARAM_TYPE {
 /** @ingroup comp */
 typedef enum OMX_EVENTTYPE
 {
-    OMX_EventCmdComplete,         /**< component has sucessfully completed a command */
+    OMX_EventCmdComplete,         /**< component has successfully completed a command */
     OMX_EventError,               /**< component has detected an error condition */
     OMX_EventMark,                /**< component has detected a buffer mark */
     OMX_EventPortSettingsChanged, /**< component is reported a port settings change */
@@ -1261,7 +1261,7 @@ OMX_API OMX_ERRORTYPE OMX_APIENTRY OMX_Deinit(void);
     @param [in] nNameLength
         number of characters in the cComponentName string.  With all 
         component name strings restricted to less than 128 characters 
-        (including the trailing null) it is recomended that the caller
+        (including the trailing null) it is recommended that the caller
         provide a input string for the cComponentName of 128 characters.
     @param [in] nIndex
         number containing the enumeration index for the component. 

--- a/opt/vc/include/IL/OMX_Index.h
+++ b/opt/vc/include/IL/OMX_Index.h
@@ -130,7 +130,7 @@ typedef enum OMX_INDEXTYPE {
     OMX_IndexConfigAudioChannelMute,        /**< reference: OMX_AUDIO_CONFIG_CHANNELMUTETYPE */
     OMX_IndexConfigAudioMute,               /**< reference: OMX_AUDIO_CONFIG_MUTETYPE */
     OMX_IndexConfigAudioLoudness,           /**< reference: OMX_AUDIO_CONFIG_LOUDNESSTYPE */
-    OMX_IndexConfigAudioEchoCancelation,    /**< reference: OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE */
+    OMX_IndexConfigAudioEchoCancellation,   /**< reference: OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE */
     OMX_IndexConfigAudioNoiseReduction,     /**< reference: OMX_AUDIO_CONFIG_NOISEREDUCTIONTYPE */
     OMX_IndexConfigAudioBass,               /**< reference: OMX_AUDIO_CONFIG_BASSTYPE */
     OMX_IndexConfigAudioTreble,             /**< reference: OMX_AUDIO_CONFIG_TREBLETYPE */

--- a/opt/vc/include/IL/OMX_Other.h
+++ b/opt/vc/include/IL/OMX_Other.h
@@ -208,7 +208,7 @@ typedef struct OMX_TIME_CONFIG_MEDIATIMEREQUESTTYPE {
  *   Upon scale changes the clock component clears the nClientPrivate data, sends the current
  *   media time and sets the nScale to the new scale via the client port. It emits a 
  *   OMX_TIME_MEDIATIMETYPE to all clients independent of any requests. This allows clients to 
- *   alter processing to accomodate scaling. For instance a video component might skip inter-frames 
+ *   alter processing to accommodate scaling. For instance a video component might skip inter-frames
  *   in the case of extreme fastforward. Likewise an audio component might add or remove samples 
  *   from an audio frame to scale audio data. 
  *
@@ -247,7 +247,7 @@ typedef struct OMX_TIME_MEDIATIMETYPE {
 
 /** Structure representing the current media time scale factor. Applicable only to clock 
  *  component, other components see scale changes via OMX_TIME_MEDIATIMETYPE buffers sent via
- *  the clock component client ports. Upon recieving this config the clock component changes 
+ *  the clock component client ports. Upon receiving this config the clock component changes
  *  the rate by which the media time increases or decreases effectively implementing trick modes. 
  */ 
 typedef struct OMX_TIME_CONFIG_SCALETYPE {

--- a/opt/vc/include/IL/OMX_Types.h
+++ b/opt/vc/include/IL/OMX_Types.h
@@ -282,7 +282,7 @@ typedef struct OMX_BS32 {
 /** Structure representing some time or duration in microseconds. This structure
   *  must be interpreted as a signed 64 bit value. The quantity is signed to accommodate 
   *  negative deltas and preroll scenarios. The quantity is represented in microseconds 
-  *  to accomodate high resolution timestamps (e.g. DVD presentation timestamps based
+  *  to accommodate high resolution timestamps (e.g. DVD presentation timestamps based
   *  on a 90kHz clock) and to allow more accurate and synchronized delivery (e.g. 
   *  individual audio samples delivered at 192 kHz). The quantity is 64 bit to 
   *  accommodate a large dynamic range (signed 32 bit values would allow only for plus

--- a/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Audio.h
+++ b/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Audio.h
@@ -1340,7 +1340,7 @@ typedef struct OMX_AUDIO_CONFIG_REVERBERATIONTYPE {
 } OMX_AUDIO_CONFIG_REVERBERATIONTYPE;
 
 
-/** Possible settings for the Echo Cancelation structure to use 
+/** Possible settings for the Echo Cancellation structure to use
  * @ingroup effects
  */
 typedef enum OMX_AUDIO_ECHOCANTYPE {
@@ -1357,16 +1357,16 @@ typedef enum OMX_AUDIO_ECHOCANTYPE {
 } OMX_AUDIO_ECHOCANTYPE;
 
 
-/** Enable / Disable for echo cancelation, which removes undesired echo's
+/** Enable / Disable for echo cancellation, which removes undesired echo's
  *  from the audio
  * @ingroup effects
  */ 
-typedef struct OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE {
+typedef struct OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE {
     OMX_U32 nSize;             /**< size of the structure in bytes */
     OMX_VERSIONTYPE nVersion;  /**< OMX specification version information */
     OMX_U32 nPortIndex;        /**< port that this structure applies to */
-    OMX_AUDIO_ECHOCANTYPE eEchoCancelation; /**< Echo cancelation settings */
-} OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE;
+    OMX_AUDIO_ECHOCANTYPE eEchoCancellation; /**< Echo cancellation settings */
+} OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE;
 
 
 /** Enable / Disable for noise reduction, which undesired noise from

--- a/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Core.h
+++ b/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Core.h
@@ -182,7 +182,7 @@ typedef enum OMX_ERRORTYPE
       lost resulting in the component returning to the loaded state */
   OMX_ErrorResourcesLost = (OMX_S32) 0x8000100D,
 
-  /** No more indicies can be enumerated */
+  /** No more indices can be enumerated */
   OMX_ErrorNoMore = (OMX_S32) 0x8000100E,
 
   /** The component detected a version mismatch */
@@ -219,7 +219,7 @@ typedef enum OMX_ERRORTYPE
       the non-supplier to return a buffer via an EmptyThisBuffer or FillThisBuffer call. */
   OMX_ErrorPortUnresponsiveDuringStop = (OMX_S32) 0x80001016,
 
-  /** Attempting a state transtion that is not allowed */
+  /** Attempting a state transition that is not allowed */
   OMX_ErrorIncorrectStateTransition = (OMX_S32) 0x80001017,
 
   /* Attempting a command that is not allowed during the present state. */
@@ -513,7 +513,7 @@ typedef struct OMX_PORT_PARAM_TYPE {
 /** @ingroup comp */
 typedef enum OMX_EVENTTYPE
 {
-    OMX_EventCmdComplete,         /**< component has sucessfully completed a command */
+    OMX_EventCmdComplete,         /**< component has successfully completed a command */
     OMX_EventError,               /**< component has detected an error condition */
     OMX_EventMark,                /**< component has detected a buffer mark */
     OMX_EventPortSettingsChanged, /**< component is reported a port settings change */
@@ -1261,7 +1261,7 @@ OMX_API OMX_ERRORTYPE OMX_APIENTRY OMX_Deinit(void);
     @param [in] nNameLength
         number of characters in the cComponentName string.  With all 
         component name strings restricted to less than 128 characters 
-        (including the trailing null) it is recomended that the caller
+        (including the trailing null) it is recommended that the caller
         provide a input string for the cComponentName of 128 characters.
     @param [in] nIndex
         number containing the enumeration index for the component. 

--- a/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Index.h
+++ b/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Index.h
@@ -130,7 +130,7 @@ typedef enum OMX_INDEXTYPE {
     OMX_IndexConfigAudioChannelMute,        /**< reference: OMX_AUDIO_CONFIG_CHANNELMUTETYPE */
     OMX_IndexConfigAudioMute,               /**< reference: OMX_AUDIO_CONFIG_MUTETYPE */
     OMX_IndexConfigAudioLoudness,           /**< reference: OMX_AUDIO_CONFIG_LOUDNESSTYPE */
-    OMX_IndexConfigAudioEchoCancelation,    /**< reference: OMX_AUDIO_CONFIG_ECHOCANCELATIONTYPE */
+    OMX_IndexConfigAudioEchoCancellation,   /**< reference: OMX_AUDIO_CONFIG_ECHOCANCELLATIONTYPE */
     OMX_IndexConfigAudioNoiseReduction,     /**< reference: OMX_AUDIO_CONFIG_NOISEREDUCTIONTYPE */
     OMX_IndexConfigAudioBass,               /**< reference: OMX_AUDIO_CONFIG_BASSTYPE */
     OMX_IndexConfigAudioTreble,             /**< reference: OMX_AUDIO_CONFIG_TREBLETYPE */

--- a/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Other.h
+++ b/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Other.h
@@ -208,7 +208,7 @@ typedef struct OMX_TIME_CONFIG_MEDIATIMEREQUESTTYPE {
  *   Upon scale changes the clock component clears the nClientPrivate data, sends the current
  *   media time and sets the nScale to the new scale via the client port. It emits a 
  *   OMX_TIME_MEDIATIMETYPE to all clients independent of any requests. This allows clients to 
- *   alter processing to accomodate scaling. For instance a video component might skip inter-frames 
+ *   alter processing to accommodate scaling. For instance a video component might skip inter-frames
  *   in the case of extreme fastforward. Likewise an audio component might add or remove samples 
  *   from an audio frame to scale audio data. 
  *
@@ -247,7 +247,7 @@ typedef struct OMX_TIME_MEDIATIMETYPE {
 
 /** Structure representing the current media time scale factor. Applicable only to clock 
  *  component, other components see scale changes via OMX_TIME_MEDIATIMETYPE buffers sent via
- *  the clock component client ports. Upon recieving this config the clock component changes 
+ *  the clock component client ports. Upon receiving this config the clock component changes
  *  the rate by which the media time increases or decreases effectively implementing trick modes. 
  */ 
 typedef struct OMX_TIME_CONFIG_SCALETYPE {

--- a/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Types.h
+++ b/opt/vc/include/interface/vmcs_host/khronos/IL/OMX_Types.h
@@ -282,7 +282,7 @@ typedef struct OMX_BS32 {
 /** Structure representing some time or duration in microseconds. This structure
   *  must be interpreted as a signed 64 bit value. The quantity is signed to accommodate 
   *  negative deltas and preroll scenarios. The quantity is represented in microseconds 
-  *  to accomodate high resolution timestamps (e.g. DVD presentation timestamps based
+  *  to accommodate high resolution timestamps (e.g. DVD presentation timestamps based
   *  on a 90kHz clock) and to allow more accurate and synchronized delivery (e.g. 
   *  individual audio samples delivered at 192 kHz). The quantity is 64 bit to 
   *  accommodate a large dynamic range (signed 32 bit values would allow only for plus

--- a/opt/vc/src/hello_pi/libs/ilclient/ilclient.h
+++ b/opt/vc/src/hello_pi/libs/ilclient/ilclient.h
@@ -508,7 +508,7 @@ VCHPRE_ void VCHPOST_  ilclient_state_transition(COMPONENT_T *list[],
  * given component.  This function sends the disable port message to
  * the component and waits for the component to signal that this has
  * taken place.  If the port is already disabled, this is treated as a
- * sucess.
+ * success.
  *
  * @param comp The component containing the port to disable.
  *
@@ -526,7 +526,7 @@ VCHPRE_ void VCHPOST_ ilclient_disable_port(COMPONENT_T *comp,
  * given component.  This function sends the enable port message to
  * the component and waits for the component to signal that this has
  * taken place.  If the port is already disabled, this is treated as a
- * sucess.
+ * success.
  *
  * @param comp The component containing the port to enable.
  *


### PR DESCRIPTION
Most of them were found and fixed using codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>