### PR TITLE
gx_create_window error cleanup fix

### DIFF
--- a/opt/vc/src/hello_pi/libs/vgfont/graphics.c
+++ b/opt/vc/src/hello_pi/libs/vgfont/graphics.c
@@ -387,7 +387,6 @@ fail_win:
    gx_priv_destroy_native_window(h);
 fail_create_native_win:
    vcos_free(h);
-   gx_priv_restore(&save);
    return status;
 }
 


### PR DESCRIPTION
In the event of an error the cleanup code for gx_create_window() was cleaning up things that hadn't happened and crashing.