### PR TITLE
Fix RGBA -> ARGB ordering in vgfont

### DIFF
--- a/hardfp/opt/vc/src/hello_pi/libs/vgfont/vgfont.h
+++ b/hardfp/opt/vc/src/hello_pi/libs/vgfont/vgfont.h
@@ -45,7 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define B_888_MASK      (0x000000FF)
 #define ALPHA_888_MASK  (0xFF000000)
 #define GRAPHICS_RGBA32( r, g, b, a ) GRAPHICS_RGBA888( r, g, b, a )
-#define GRAPHICS_RGBA888( r, g, b, a ) ( (((a) << (8+8+8)) & ALPHA_888_MASK) | (((b) << (8+8)) & R_888_MASK) | (((g) << 8) & G_888_MASK) | ((r) & B_888_MASK) )
+#define GRAPHICS_RGBA888( r, g, b, a ) ( (((a) << (8+8+8)) & ALPHA_888_MASK) | (((r) << (8+8)) & R_888_MASK) | (((g) << 8) & G_888_MASK) | ((b) & B_888_MASK) )
 #define GRAPHICS_TRANSPARENT_COLOUR 0x00000001UL
 
 //resource defs

--- a/opt/vc/src/hello_pi/libs/vgfont/vgfont.h
+++ b/opt/vc/src/hello_pi/libs/vgfont/vgfont.h
@@ -45,7 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define B_888_MASK      (0x000000FF)
 #define ALPHA_888_MASK  (0xFF000000)
 #define GRAPHICS_RGBA32( r, g, b, a ) GRAPHICS_RGBA888( r, g, b, a )
-#define GRAPHICS_RGBA888( r, g, b, a ) ( (((a) << (8+8+8)) & ALPHA_888_MASK) | (((b) << (8+8)) & R_888_MASK) | (((g) << 8) & G_888_MASK) | ((r) & B_888_MASK) )
+#define GRAPHICS_RGBA888( r, g, b, a ) ( (((a) << (8+8+8)) & ALPHA_888_MASK) | (((r) << (8+8)) & R_888_MASK) | (((g) << 8) & G_888_MASK) | ((b) & B_888_MASK) )
 #define GRAPHICS_TRANSPARENT_COLOUR 0x00000001UL
 
 //resource defs


### PR DESCRIPTION
GRAPHICS_RGBA888(r,g,b,a) currently packs into a uint32_t like "ABGR", but the unpacking function in graphics.c ([here](https://github.com/raspberrypi/firmware/blob/983b091aa491dc6b47e5cc62abb281dbcb75088d/opt/vc/src/hello_pi/libs/vgfont/graphics.c#L641-L648)) expects the uint32_t to be packed in "ARGB" to produce its rgba[4] array of VGfloats.
