### PR TITLE
uart5 are GPIO pins 12 and 13, not 12 and 15

### DIFF
--- a/boot/overlays/README
+++ b/boot/overlays/README
@@ -3517,7 +3517,7 @@ Params: ctsrts                  Enable CTS/RTS on GPIOs 10-11 (default off)
 
 
 Name:   uart5
-Info:   Enable uart 5 on GPIOs 12-15. BCM2711 only.
+Info:   Enable uart 5 on GPIOs 12-13. BCM2711 only.
 Load:   dtoverlay=uart5,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 14-15 (default off)
 


### PR DESCRIPTION
I tested the pins on UART5, the listed pins are incorrect in this document, but are correct on raspi-gpio funcs
```
pi@raspberrypi:~ $ raspi-gpio funcs
GPIO, DEFAULT PULL, ALT0, ALT1, ALT2, ALT3, ALT4, ALT5
12, DOWN, PWM0_0, SD4, DPI_D8, SPI5_CE0_N, TXD5, SDA5
13, DOWN, PWM0_1, SD5, DPI_D9, SPI5_MISO, RXD5, SCL5
```

I tested this writing to an ATTiny404 and it worked using GPIOs 12 and 13, but not GPIOs 12 and 15.