### PR TITLE
Update the description for i2c_gpio_delay_us

### DIFF
--- a/boot/overlays/README
+++ b/boot/overlays/README
@@ -1914,7 +1914,7 @@ Params: i2c_gpio_sda            GPIO used for I2C data (default "23")
         i2c_gpio_scl            GPIO used for I2C clock (default "24")
 
         i2c_gpio_delay_us       Clock delay in microseconds
-                                (default "2" = ~100kHz)
+                                (default "5" = ~100kHz)
 
         bus                     Set to a unique, non-zero value if wanting
                                 multiple i2c-gpio busses. If set, will be used


### PR DESCRIPTION
The description of default value shall be  5 that related to ~100kHZ
According to the i2c_gpio_probe() of i2c-gpio.c