### PR TITLE
backup-switchover-mode value definitions improvement

### DIFF
--- a/boot/overlays/README
+++ b/boot/overlays/README
@@ -2106,7 +2106,13 @@ Params: abx80x                  Select one of the ABx80x family:
                                 source
 
         backup-switchover-mode  Backup power supply switch mode. Must be 0 for
-                                off or 1 for Vdd < VBackup (RV3028, RV3032)
+                                "Switchover disabled", 1 for "Direct Switching" 
+                                (switchover when Vdd < VBackup), 2 for "Standby
+                                 Mode" (go into standby when Vdd < Vbackup, 
+                                does not draw current) or 3 (recommended) for 
+                                "Level Switching" (switchover when Vdd < Vbackup 
+                                and Vdd < Vddsw and Vbackup > Vddsw.) 
+                                (RV3028, RV3032)
 
 
 Name:   i2c-rtc-gpio


### PR DESCRIPTION
For the RV3028 RTC, the definitions for its `backup-switchover-mode` overlay where not intelligible neither complete/exhaustive.

Accordingly to the https://github.com/raspberrypi/linux/issues/2912#issuecomment-477670051, these should be correct.