### PR TITLE
Update README

### DIFF
--- a/boot/overlays/README
+++ b/boot/overlays/README
@@ -5274,7 +5274,7 @@ Params: ctsrts                  Enable CTS/RTS on GPIOs 6-7 (default off)
 
 
 Name:   uart3
-Info:   Enable uart 3 on GPIOs 4-7. BCM2711 only.
+Info:   Enable uart 3 on GPIOs 4-5. BCM2711 only.
 Load:   dtoverlay=uart3,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 6-7 (default off)
         rs485                   Enable RS485 mode for using the RTS line to


### PR DESCRIPTION
Changed UART3 GPIO to 4 (TXD) / 5(RXD) instead of [4-7](https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README#L5277C31-L5277C35).

Source: https://pinout.xyz/pinout/uart